### PR TITLE
Issue #11 Ensure generated index.js is in lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": ["specs", "lib", "node_modules"],
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
@@ -28,7 +31,7 @@
     "module": "ES6" /* Specify what module code is generated. */,
     // "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "Node" /* Specify how TypeScript looks up a file from a given module specifier. */,
-    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
+    "baseUrl": "./src" /* Specify the base directory to resolve non-relative module names. */,
     "paths": {} /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */


### PR DESCRIPTION
Following `npm run build` the `index.js` and related build artefacts were ending up in the `lib/src/` folder, rather than the `lib` folder, creating a mismatch between `package.json` entry definitions.

This PR deals with this.